### PR TITLE
concealment of codeblocks

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -121,11 +121,9 @@ syn region pandocStrikeout matchgroup=Operator start=/\~\~/ end=/\~\~/  contains
 " this is here because we can override strikeouts and subscripts
 syn region pandocDelimitedCodeBlock start=/^\z(\~\{3,}\~*\)/ end=/\z1\~*/ skipnl contains=pandocDelimitedCodeBlockStart keepend
 syn region pandocDelimitedCodeBlock start=/^\z(`\{3,}`*\)/ end=/\z1`*/ skipnl contains=pandocDelimitedCodeBlockStart keepend
-syn match pandocDelimitedCodeBlockStart /\(\_^\n\_^\)\@<=\~\{3,}\~*/ contained nextgroup=pandocDelimitedCodeBlockLanguage conceal cchar=λ
-syn match pandocDelimitedCodeBlockStart /\(\_^\n\_^\)\@<=`\{3,}`*/ contained nextgroup=pandocDelimitedCodeBlockLanguage conceal cchar=λ
+syn match pandocDelimitedCodeBlockStart /\(\_^\n\_^\)\@<=\(\~\{3,}\~*\|`\{3,}`*\)/ contained nextgroup=pandocDelimitedCodeBlockLanguage conceal cchar=λ
 syn match pandocDelimitedCodeBlockLanguage /\(\s\?\)\@<=.\+\(\_$\)\@=/ contained
-syn match pandocDelimitedCodeBlockEnd /`\{3,}`*\(\_$\n\_$\)\@=/ contained containedin=pandocDelimitedCodeBlock conceal
-syn match pandocDelimitedCodeBlockEnd /\~\{3,}\~*\(\_$\n\_$\)\@=/ contained containedin=pandocDelimitedCodeBlock conceal
+syn match pandocDelimitedCodeBlockEnd /\(`\{3,}`*\|\~\{3,}\~*\)\(\_$\n\_$\)\@=/ contained containedin=pandocDelimitedCodeBlock conceal
 syn match pandocCodePre /<pre>.\{-}<\/pre>/ skipnl
 syn match pandocCodePre /<code>.\{-}<\/code>/ skipnl
 " }}}


### PR DESCRIPTION
I've added concealment of codeblocks as mentioned in #2 . See [here](https://github.com/vim-pandoc/vim-pandoc-syntax/issues/2#issuecomment-28265858) for screenshots of what it looks like, personally I love it.

I added duplicate patterns for the backtick and tilde codeblocks, because I wasn't sure how I should merge them, since I figured that if I did it wrong, it would mean that I could open with backticks and close with tildes. With the duplicates, this doesn't occur.
