### PR TITLE
fix definition block regression

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -176,7 +176,7 @@ syn match pandocFootnoteIDTail /\]/ contained containedin=pandocFootnoteID conce
 
 " Definitions: {{{1
 "
-syn region pandocDefinitionBlock start=/^.*\n\(^\s*\n\)*\s\{0,2}[:~]/ skip=/\n\n\zs\s/ end=/\n\n/ contains=pandocDefinitionBlockMark,pandocDefinitionBlockTerm,pandocCodeBlockInsideIndent,pandocEmphasis,pandocStrong,pandocStrongEmphasis,pandocNoFormatted,pandocStrikeout,pandocSubscript,pandocSuperscript,pandocFootnoteID,pandocLinkArea,pandocAutomaticLink keepend 
+syn region pandocDefinitionBlock start=/^.*\n\(^\s*\n\)*\s\{0,2}[:~]\(\~\{2,}\~*\)\@!/ skip=/\n\n\zs\s/ end=/\n\n/ contains=pandocDefinitionBlockMark,pandocDefinitionBlockTerm,pandocCodeBlockInsideIndent,pandocEmphasis,pandocStrong,pandocStrongEmphasis,pandocNoFormatted,pandocStrikeout,pandocSubscript,pandocSuperscript,pandocFootnoteID,pandocLinkArea,pandocAutomaticLink keepend 
 syn match pandocDefinitionBlockTerm /^.*\n\(^\s*\n\)*\(\s*[:~]\)\@=/ contained contains=pandocNoFormatted,pandocEmphasis,pandocStrong
 syn match pandocDefinitionBlockMark /^\s*[:~]/ contained conceal cchar= 
 " }}}

--- a/tests/block.pdc
+++ b/tests/block.pdc
@@ -66,6 +66,10 @@ def func(a):
     return 1
 ~~~
 
+~~~ {.python}
+print("hi")
+~~~
+
 test
 
     ~~~haskell


### PR DESCRIPTION
As explained in #20, this makes the definition block region start pattern more strict to avoid it having match codeblock tildes. Added test case as well as tested on my own documents. Seems to have fixed the issue entirely.
