### PR TITLE
Add generated "doc/tags" to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.html
 *.pdf
 *.swp
+doc/tags


### PR DESCRIPTION
Just a small change, but as I manage my vim plugins with git submodules, the generated doc/tags keeps appearing as untracked content in my repo
