### PR TITLE
implement g:pandoc_syntax_ignore_codeblocks

### DIFF
--- a/doc/pandoc-syntax.txt
+++ b/doc/pandoc-syntax.txt
@@ -18,8 +18,10 @@ CONFIGURATION				       *pandoc-syntax-confguration*
 
       let g:pandoc_syntax_user_cchars = ["footnote" : "*"]
 
-+ *g:pandoc_syntax_fill_codeblocks*
-  Highlight codeblocks in a different color to normal text. Default = 1. 
++ *g:pandoc_syntax_ignore_codeblocks*
+  Prevent highlighting specific codeblock types so that they remain Normal.
+  Codeblock types include 'definition' for codeblocks inside definition blocks
+  and 'delimited' for delimited codeblocks. Default = []
 
 + *g:pandoc_use_embeds_in_codeblocks*
   Use embedded highlighting for delimited codeblocks where a language is

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -48,9 +48,9 @@ if exists("g:pandoc_syntax_user_cchars")
     let s:cchars = extend(s:cchars, g:pandoc_syntax_user_cchars)
 endif
 "}}}2
-" highlight codeblocks differently to normal text {{{2
-if !exists("g:pandoc_syntax_fill_codeblocks")
-    let g:pandoc_syntax_fill_codeblocks = 1
+" leave specified codeblocks as Normal (i.e. 'unhighlighted') {{{2
+if !exists("g:pandoc_syntax_ignore_codeblocks")
+    let g:pandoc_syntax_ignore_codeblocks = []
 endif
 "}}}2
 " use embedded highlighting for delimited codeblocks where a language is specifed. {{{2
@@ -158,7 +158,6 @@ syn match pandocBlockQuote /^>.*\n\(.*\n\@<!\n\)*/ contains=@Spell,pandocEmphasi
 
 " Code Blocks: {{{1
 "
-syn region pandocCodeBlock   start=/\(\(\d\|\a\|*\).*\n\)\@<!\(^\(\s\{4,}\|\t\+\)\).*\n/ end=/.\(\n^\s*\n\)\@=/
 syn region pandocCodeBlockInsideIndent   start=/\(\(\d\|\a\|*\).*\n\)\@<!\(^\(\s\{8,}\|\t\+\)\).*\n/ end=/.\(\n^\s*\n\)\@=/ contained
 "}}}
 
@@ -395,12 +394,18 @@ hi link pandocSetexHeader Title
 
 hi link pandocHTMLComment Comment
 hi link pandocBlockQuote Comment
-hi link pandocCodeBlock String
-hi link pandocCodeBlockInsideIndent String
-" if the user sets g:pandoc_syntax_fill_codeblocks to 0, we use Normal
-if !exists("g:pandoc_syntax_fill_codeblocks") || g:pandoc_syntax_fill_codeblocks != 0
-    hi link pandocDelimitedCodeBlock Special
+
+" if the user sets g:pandoc_syntax_ignore_codeblocks to contain
+" a codeblock type, don't highlight it so that it remains Normal
+
+if index(g:pandoc_syntax_ignore_codeblocks, 'definition') == -1
+  hi link pandocCodeBlockInsideIndent String
 endif
+
+if index(g:pandoc_syntax_ignore_codeblocks, 'delimited') == -1
+  hi link pandocDelimitedCodeBlock Special
+endif
+
 hi link pandocDelimitedCodeBlockStart Delimiter
 hi link pandocDelimitedCodeBlockEnd Delimiter
 hi link pandocDelimitedCodeBlockLanguage Comment


### PR DESCRIPTION
Posting this up for review. So this is in response to #46. I've reimplemented `g:pandoc_syntax_fill_codeblocks` as `g:pandoc_syntax_ignore_codeblocks` which takes a list of codeblock types to ignore. The only two types that can be defined in that list are `delimited` for delimited codeblocks and `definition` for codeblocks in definitions. As was discussed, regular indented codeblocks are no longer highlighted.

As a result, I got rid of the region rule for them, since it's not being used for anything. If we should need it in the future we can simply pull it back out from an earlier commit. What do you think?

I also added some documentation on it, replacing the previous option's documentation.

Wanted to hear what you think before merging it in.
