### PR TITLE
Hash in header

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -238,7 +238,7 @@ call s:WithConceal("strikeout", 'syn match pandocStrikeoutMark /\~\~/ contained 
 " Headers: {{{1
 "
 syn match pandocAtxHeader /^\s*#\{1,6}.*\n/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted display
-syn match pandocAtxHeaderMark /^\s*#\{1,6}/ contained containedin=pandocAtxHeader
+syn match pandocAtxHeaderMark /\(^\s*#\{1,6}\|#*\s*$\)/ contained containedin=pandocAtxHeader
 call s:WithConceal("atx", 'syn match AtxStart /#/ contained containedin=pandocAtxHeaderMark', 'conceal cchar='.s:cchars["atx"])
 syn match pandocSetexHeader /^.\+\n[=]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted
 syn match pandocSetexHeader /^.\+\n[-]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted

--- a/tests/headings.pdc
+++ b/tests/headings.pdc
@@ -2,11 +2,11 @@
 % vim-pandoc-syntax  
   with multiple lines
 
-# heading 
+# heading #
 
 a
 
-## heading with # in it
+## heading with # in it ##
 
 a
 


### PR DESCRIPTION
Hi,

Headings (atx-style) may contain a # sign as part of the text. These signs should not be concealed (i.e., replaced with § signs).

These commits ensure that only leading and trailing # signs are highlighted and concealed.

Thanks,
