### PR TITLE
Filetype detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@ from `vim-pandoc/vim-pandoc`.
 
 compatible with vim versions having `+conceal`.
 
+Filetype Detection and File Extensions
+======================================
+
+If you have this plugin installed alongside [vim-markdown][], be aware
+that both plugins attempt to claim the common markdown extensions for
+their own. We match the following extensions:
+
++    .markdown, .md, .mkd, .pd, .pdk, .pandoc, and .text
+
+In our experience, vim-pandoc trumps vim-markdown.
+
+We do not claim files with the `.txt` extension, since that would seem
+a bit presumptuous. If you want `.txt` files to be treated as pandoc
+files, add
+
+    autocmd BufNewFile,BufRead *.txt   set filetype=pandoc
+
+to your `.vimrc`.
+
+[vim-markdown]: http://plasticboy.com/markdown-vim-mode/
+
 ## features
 
 * supports most (if not all) pandoc's markdown features.

--- a/ftdetect/pandoc.vim
+++ b/ftdetect/pandoc.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.markdown,*.md,*.mkd,*.pd,*.pdc,*.pdk,*.pandoc,*.text   set filetype=pandoc


### PR DESCRIPTION
This enables the file type detection.  I snagged the file `ftdetect/pandoc.vm` from the original [vim-pandoc](https://github.com/vim-pandoc/vim-pandoc) project.  I went ahead and added the relevant information to the README as well.  As an aside, I believe this also fixes issue #39.
