### PR TITLE
fix for hyperlinks like [here](URI)

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -218,7 +218,7 @@ syn region pandocCodeBlockInsideIndent   start=/\(\(\d\|\a\|*\).*\n\)\@<!\(^\(\s
 syn region pandocReferenceLabel matchgroup=Operator start=/!\{,1}\[/ skip=/\]\]\@=/ end=/\]/ keepend display
 syn region pandocReferenceURL matchgroup=Operator start=/\]\@1<=(/ end=/)/ keepend display
 " let's not consider "a [label] a" as a label, remove formatting - Note: breaks implicit links
-syn match pandocNoLabel /\]\@<!\s*\[[^\[\]]\{-}\]\s*\[\@!/ contains=pandocPCite
+syn match pandocNoLabel /\]\@1<!\s*\[[^\[\]]\{-}\]\s*[\[(]\@!/ contains=pandocPCite
 syn match pandocLinkTip /\s*".\{-}"/ contained containedin=pandocReferenceURL contains=@Spell display
 call s:WithConceal("image", 'syn match pandocImageIcon /!\[\@=/ display', 'conceal cchar='. s:cchars["image"]) 
 " }}}


### PR DESCRIPTION
The issue was introduced in fix for issue #80. This fix will
additionally check that next character is not opening parenthesis.
