### PR TITLE
fix highlighting headers with leading #

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -304,8 +304,8 @@ call s:WithConceal("strikeout", 'syn match pandocStrikeoutMark /\~\~/ contained 
 
 " Headers: {{{1
 "
-syn match pandocAtxHeader /\(\%^\|^\s*\n\)\@<=\s*#\{1,6}.*\n/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell display
-syn match pandocAtxHeaderMark /\(^\s*#\{1,6}\|\\\@<!#*\(\s*.*$\)\@=\)/ contained containedin=pandocAtxHeader
+syn match pandocAtxHeader /\(\%^\|^\s*\n\)\@<=#\{1,6}.*\n/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell display
+syn match pandocAtxHeaderMark /\(^#\{1,6}\|\\\@<!#*\(\s*.*$\)\@=\)/ contained containedin=pandocAtxHeader
 call s:WithConceal("atx", 'syn match pandocAtxStart /#/ contained containedin=pandocAtxHeaderMark', 'conceal cchar='.s:cchars["atx"])
 syn match pandocSetexHeader /^.\+\n[=]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell
 syn match pandocSetexHeader /^.\+\n[-]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell


### PR DESCRIPTION
a heading has to start with a `#`

take a look at [this](http://johnmacfarlane.net/pandoc/try/?text=+%23+header%0A%0Ahiho&from=markdown&to=html) for example.
