### PR TITLE
Match latex in headers

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -304,11 +304,11 @@ call s:WithConceal("strikeout", 'syn match pandocStrikeoutMark /\~\~/ contained 
 
 " Headers: {{{1
 "
-syn match pandocAtxHeader /\(\%^\|^\s*\n\)\@<=#\{1,6}.*\n/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell display
-syn match pandocAtxHeaderMark /\(^#\{1,6}\|\\\@<!#*\(\s*.*$\)\@=\)/ contained containedin=pandocAtxHeader
+syn match pandocAtxHeader /\(\%^\|^\s*\n\)\@<=#\{1,6}.*\n/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,pandocLaTeXInlineMath,@Spell, display
+syn match pandocAtxHeaderMark /\(^#\{1,6}\|\\\@<!#\+\(\s*.*$\)\@=\)/ contained containedin=pandocAtxHeader
 call s:WithConceal("atx", 'syn match pandocAtxStart /#/ contained containedin=pandocAtxHeaderMark', 'conceal cchar='.s:cchars["atx"])
-syn match pandocSetexHeader /^.\+\n[=]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell
-syn match pandocSetexHeader /^.\+\n[-]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,@Spell
+syn match pandocSetexHeader /^.\+\n[=]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,pandocLaTeXInlineMath,@Spell
+syn match pandocSetexHeader /^.\+\n[-]\+$/ contains=pandocEmphasis,pandocStrong,pandocNoFormatted,pandocLaTeXInlineMath,@Spell
 syn match pandocHeaderAttr /{.*}/ contained containedin=pandocAtxHeader,pandocSetexHeader
 syn match pandocHeaderID /#[-_:.[:alpha:]]*/ contained containedin=pandocHeaderAttr
 "}}}


### PR DESCRIPTION
Here's a pull request to match latex in headers.

Please note that I also changed the pattern for pandocAtxHeaderMark.  I honestly don't know what you are trying to match with that pattern.  I am guessing you were trying to not match a # that is preceded by a \, but what was happening is that anything that followed a \ was not being matched.  I swapped the 0 or more # (#*) for 1 or more # (#+).  Please let me know if I actually messed something up here!
