### PR TITLE
highlight HTML tags like </p> correctly

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -193,7 +193,7 @@ endif
 " HTML: {{{3
 " Set embedded HTML highlighting
 syn include @HTML syntax/html.vim
-syn match pandocHTML /<\/\?\a[^>]*>/ contains=@HTML
+syn match pandocHTML /<\/\?\a.\{-}>/ contains=@HTML
 " Support HTML multi line comments
 syn region pandocHTMLComment start=/<!--\s\=/ end=/\s\=-->/ keepend contains=pandocHTMLCommentStart,pandocHTMLCommentEnd
 call s:WithConceal('html_c_s', 'syn match pandocHTMLCommentStart /<!--/ contained', 'conceal cchar='.s:cchars['html_c_s'])

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -193,7 +193,7 @@ endif
 " HTML: {{{3
 " Set embedded HTML highlighting
 syn include @HTML syntax/html.vim
-syn match pandocHTML /<\/\?\a[^>]\+>/ contains=@HTML
+syn match pandocHTML /<\/\?\a[^>]*>/ contains=@HTML
 " Support HTML multi line comments
 syn region pandocHTMLComment start=/<!--\s\=/ end=/\s\=-->/ keepend contains=pandocHTMLCommentStart,pandocHTMLCommentEnd
 call s:WithConceal('html_c_s', 'syn match pandocHTMLCommentStart /<!--/ contained', 'conceal cchar='.s:cchars['html_c_s'])


### PR DESCRIPTION
One-letter HTML tags like ``<p>`` and ``</p>`` were not correctly highlighted (not highlighted at all).

Regexp part ``[^>]*>`` may be reworked more elegantly as ``.\{-}>``, both cases work for me.