### PR TITLE
correct highlights of hrules and YAML headers

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -459,7 +459,7 @@ try
     syn include @YAML syntax/yaml.vim
 catch /E484/
 endtry
-syn region pandocYAMLHeader start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ contains=@YAML containedin=TOP
+syn region pandocYAMLHeader start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ keepend contains=@YAML containedin=TOP
 "}}}
 "}}}1
 

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -445,7 +445,7 @@ if &encoding == "utf-8"
     call s:WithConceal("quotes", 'syn match pandocEndQuote /\(\>[[:punct:]]*\)\@<="[[:blank:][:punct:]\n]\@=/  containedin=pandocEmphasis,pandocStrong,pandocUListItem,pandocListItem,pandocListItemContinuation display', 'conceal cchar=”')
 endif
 " Hrule: {{{3
-syn match pandocHRule /^\s*\([*-_]\)\s*\%(\1\s*\)\{2,}$/ display
+syn match pandocHRule /^\s*\([*\-_]\)\s*\%(\1\s*\)\{2,}$/ display
 " Backslashes: {{{3
 if g:pandoc#syntax#conceal#backslash == 1
     syn match pandocBackslash /\\\@<!\\/ containedin=ALLBUT,pandocCodeblock,pandocCodeBlockInsideIndent,pandocNoFormatted,pandocNoFormattedInEmphasis,pandocNoFormattedInStrong,pandocDelimitedCodeBlock,pandocLineBlock,pandocYAMLHeader conceal

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -459,7 +459,7 @@ try
     syn include @YAML syntax/yaml.vim
 catch /E484/
 endtry
-syn region pandocYAMLHeader matchgroup=Delimiter start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ contains=@YAML containedin=TOP
+syn region pandocYAMLHeader start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ contains=@YAML containedin=TOP
 "}}}
 "}}}1
 

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -333,24 +333,24 @@ syn match pandocLineBlockDelimiter /^|/ contained containedin=pandocLineBlock
 
 " Simple: {{{3
 
-syn region pandocSimpleTable start=/\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)\(-\+\s*\)\+\n\n\@!/ end=/\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock keepend
+syn region pandocSimpleTable start=/\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)\(-\+\s*\)\+\n\n\@!/ end=/\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend
 syn match pandocSimpleTableDelims /\-/ contained containedin=pandocSimpleTable
 syn match pandocSimpleTableHeader /\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)/ contained containedin=pandocSimpleTable
 
-syn region pandocTable start=/\%#=2^\(-\+\s*\)\+\n\n\@!/ end=/\%#=2^\(-\+\s*\)\+\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock keepend
+syn region pandocTable start=/\%#=2^\(-\+\s*\)\+\n\n\@!/ end=/\%#=2^\(-\+\s*\)\+\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend
 syn match pandocTableDelims /\-/ contained containedin=pandocTable
 syn region pandocTableMultilineHeader start=/\%#=2\(^-\+\n\)\@<=./ end=/\%#=2\n-\@=/ contained containedin=pandocTable
 
 " }}}3
 " Grid: {{{3
-syn region pandocGridTable start=/\%#=2\n\@1<=+-/ end=/+\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock keepend
+syn region pandocGridTable start=/\%#=2\n\@1<=+-/ end=/+\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend
 syn match pandocGridTableDelims /[\|=]/ contained containedin=pandocGridTable
 syn match pandocGridTableDelims /\%#=2\([\-+][\-+=]\@=\|[\-+=]\@1<=[\-+]\)/ contained containedin=pandocGridTable
 syn match pandocGridTableHeader /\%#=2\(^.*\n\)\(+=.*\)\@=/ contained containedin=pandocGridTable 
 "}}}3
 " Pipe: {{{3
 " with beginning and end pipes
-syn region pandocPipeTable start=/\%#=2\([+|]\n\)\@<!\n\@1<=|\(.*|\)\@=/ end=/|.*\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock keepend 
+syn region pandocPipeTable start=/\%#=2\([+|]\n\)\@<!\n\@1<=|\(.*|\)\@=/ end=/|.*\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend 
 " without beginning and end pipes
 syn region pandocPipeTable start=/\%#=2^.*\n-.\{-}|/ end=/|.*\n\n/ keepend
 syn match pandocPipeTableDelims /[\|\-:+]/ contained containedin=pandocPipeTable
@@ -448,7 +448,7 @@ endif
 syn match pandocHRule /^\s*\([*-_]\)\s*\%(\1\s*\)\{2,}$/ display
 " Backslashes: {{{3
 if g:pandoc#syntax#conceal#backslash == 1
-    syn match pandocBackslash /\\\@<!\\/ containedin=ALLBUT,pandocCodeblock,pandocCodeBlockInsideIndent,pandocNoFormatted,pandocNoFormattedInEmphasis,pandocNoFormattedInStrong,pandocDelimitedCodeBlock,pandocLineBlock conceal
+    syn match pandocBackslash /\\\@<!\\/ containedin=ALLBUT,pandocCodeblock,pandocCodeBlockInsideIndent,pandocNoFormatted,pandocNoFormattedInEmphasis,pandocNoFormattedInStrong,pandocDelimitedCodeBlock,pandocLineBlock,pandocYAMLHeader conceal
 endif
 " }}}
 " }}}

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -445,7 +445,7 @@ if &encoding == "utf-8"
     call s:WithConceal("quotes", 'syn match pandocEndQuote /\(\>[[:punct:]]*\)\@<="[[:blank:][:punct:]\n]\@=/  containedin=pandocEmphasis,pandocStrong,pandocUListItem,pandocListItem,pandocListItemContinuation display', 'conceal cchar=”')
 endif
 " Hrule: {{{3
-syn match pandocHRule /\*\{3}$/ display
+syn match pandocHRule /^\s*\([*-_]\)\s*\%(\1\s*\)\{2,}$/ display
 " Backslashes: {{{3
 if g:pandoc#syntax#conceal#backslash == 1
     syn match pandocBackslash /\\\@<!\\/ containedin=ALLBUT,pandocCodeblock,pandocCodeBlockInsideIndent,pandocNoFormatted,pandocNoFormattedInEmphasis,pandocNoFormattedInStrong,pandocDelimitedCodeBlock,pandocLineBlock conceal
@@ -459,7 +459,7 @@ try
     syn include @YAML colors/yaml.vim
 catch /E484/
 endtry
-syn region pandocYAMLHeader matchgroup=Delimiter start=/\(\%^\|\(\s*.*\n\)\)\@<=\-\{3}\s*$/ end=/[\-|\.]\{3}\s*$/ contains=@YAML containedin=TOP 
+syn region pandocYAMLHeader matchgroup=Delimiter start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ contains=@YAML containedin=TOP
 "}}}
 "}}}1
 

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -456,7 +456,7 @@ endif
 
 try
     unlet! b:current_syntax
-    syn include @YAML colors/yaml.vim
+    syn include @YAML syntax/yaml.vim
 catch /E484/
 endtry
 syn region pandocYAMLHeader matchgroup=Delimiter start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ contains=@YAML containedin=TOP


### PR DESCRIPTION
Highlight horizontal rules according to
http://johnmacfarlane.net/pandoc/README.html#horizontal-rules
(i.e. 3 possible symbols optionally delimited or surrounded by spaces).

Correctly distinguish hrules and YAML headers: the latter must begin
from line with exactly 3 dashes followed by non-blank line. This is not
clearly stated in pandoc docs but is as implemented in pandoc: see
source code of function yamlMetaBlock from
http://hackage.haskell.org/package/pandoc-1.13.2/docs/src/Text-Pandoc-Readers-Markdown.html,
here is an excerpt:

```haskell
yamlMetaBlock = try $ do
  guardEnabled Ext_yaml_metadata_block
  pos <- getPosition
  string "---"
  blankline
  notFollowedBy blankline  -- if --- is followed by a blank it's an HRULE
```

This commit must also fix #119