### PR TITLE
Fix pandocPipeTable highlighting

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -357,7 +357,7 @@ syn match pandocGridTableHeader /\%#=2\(^.*\n\)\(+=.*\)\@=/ contained containedi
 "}}}3
 " Pipe: {{{3
 " with beginning and end pipes
-syn region pandocPipeTable start=/\%#=2\([+|]\n\)\@<!\n\@1<=|\(.*|\)\@=/ end=/|.*\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend 
+syn region pandocPipeTable start=/\%#=2\([+|]\n\)\@<!\n\@1<=|\(.*|\)\@=/ end=/|.*\n\(\n\|{\)/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend 
 " without beginning and end pipes
 syn region pandocPipeTable start=/\%#=2^.*\n-.\{-}|/ end=/|.*\n\n/ keepend
 syn match pandocPipeTableDelims /[\|\-:+]/ contained containedin=pandocPipeTable


### PR DESCRIPTION
For some of my Markdown projects, I use kramdown which has support
for block inline attribute lists. The code to check for piped tables
doesn't quite play nicely when I try to add a class to it. For example,
in the following snippit the table never ends according to the current
code:

```markdown
| Heading 1         | Heading 2 |
| ---------         | --------- |
| vim-pandoc-syntax | is        |
| so                | great     |
{:sparkling}

## Not Styled as Heading!

Oh noes :'(
```

This fixes the problem by just checking to see if there's a `{`
character there.