### PR TITLE
Add `inlinecode` to doc

### DIFF
--- a/doc/pandoc-syntax.txt
+++ b/doc/pandoc-syntax.txt
@@ -37,6 +37,7 @@ CONFIGURATION				       *vim-pandoc-syntax-configuration*
   - dashes
   - ellipses
   - quotes
+  - inlinecode
 
   To review what are the rules for, look for the call to |s:WithConceal| in
   syntax/pandoc.vim that takes the corresponding  rulename as first argument.


### PR DESCRIPTION
Add `inlinecode` to the list of blacklistable conceal rules.