### PR TITLE
Check 'termguicolors' instead of 'nvim'

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -584,7 +584,7 @@ if g:pandoc#syntax#style#emphases == 1
     if !exists('s:hi_tail')
         for s:i in ["fg", "bg"]
             let s:tmp_val = synIDattr(synIDtrans(hlID("String")), s:i)
-            let s:tmp_ui =  has('gui_running') || has('nvim') ? 'gui' : 'cterm'
+            let s:tmp_ui =  has('gui_running') || (has('termguicolors') && &termguicolors) ? 'gui' : 'cterm'
             if !empty(s:tmp_val) && s:tmp_val != -1
                 exe 'let s:'.s:i . ' = "'.s:tmp_ui.s:i.'='.s:tmp_val.'"'
             else


### PR DESCRIPTION
What we're really trying to detect here is whether the highlighting is
being done using GUI colors or terminal color codes. This change
reflects that. Just because it's Neovim doesn't mean it's GUI colors. Just
because it's normal Vim doesn't mean it's terminal colors.

In the absence of this change, this is the error (from Vim):

```
Error detected while processing /<redacted>/.vim/bundle/vim-pandoc-syntax/syntax/pandoc.vim:

line  597:
E421: Color name or number not recognized: ctermfg=#2aa198
Press ENTER or type command to continue
```