### PR TITLE
Fix automatic links by restricting characters in mail links.

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -264,7 +264,7 @@ syn match pandocReferenceDefinitionAddress /:\s*\zs.*/ contained containedin=pan
 syn match pandocReferenceDefinitionTip /\s*".\{-}"/ contained containedin=pandocReferenceDefinition,pandocReferenceDefinitionAddress contains=@Spell
 "}}}
 " Automatic_links: {{{3
-syn match pandocAutomaticLink /<\(https\{0,1}.\{-}\|.\{-}@.\{-}\..\{-}\)>/ contains=NONE
+syn match pandocAutomaticLink /<\(https\{0,1}.\{-}\|[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~.]\{-}@[A-Za-z0-9\-]\{-}\.\w\{-}\)>/ contains=NONE
 " }}}
 "}}}
 " Citations: {{{2


### PR DESCRIPTION
(This was raised in Issue #186.)

Previously, pandocAutomaticLink captures too much in the e-mail side. For example, the following is captured as a single e-mail link:

    <div>Here is a sentence with a @citation. Here is another sentence.</div>

The presence of the @ and . in between any < and >, regardless of other content will result in a match.

What's needed is to restrict e-mail addresses to a certain range of characters, not including the space character. (See https://en.wikipedia.org/wiki/Email_address#Syntax.) This patch fixes this.