### PR TITLE
Citation fix

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -246,7 +246,7 @@ syn region pandocCodeBlockInsideIndent   start=/\(\(\d\|\a\|*\).*\n\)\@<!\(^\(\s
 " Links: {{{2
 "
 " Base: {{{3
-syn region pandocReferenceLabel matchgroup=pandocOperator start=/!\{,1}\\\@<!\[/ skip=/\(\\\@<!\]\]\@=\|`.*\\\@<!].*`\)/ end=/\\\@<!\]/ keepend display
+syn region pandocReferenceLabel matchgroup=pandocOperator start=/!\{,1}\\\@<!\^\@<!\[/ skip=/\(\\\@<!\]\]\@=\|`.*\\\@<!].*`\)/ end=/\\\@<!\]/ keepend display
 if g:pandoc#syntax#conceal#urls == 1
     syn region pandocReferenceURL matchgroup=pandocOperator start=/\]\@1<=(/ end=/)/ keepend conceal
 else

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -264,7 +264,7 @@ syn match pandocReferenceDefinitionAddress /:\s*\zs.*/ contained containedin=pan
 syn match pandocReferenceDefinitionTip /\s*".\{-}"/ contained containedin=pandocReferenceDefinition,pandocReferenceDefinitionAddress contains=@Spell
 "}}}
 " Automatic_links: {{{3
-syn match pandocAutomaticLink /<\(https\{0,1}.\{-}\|.\{-}@.\{-}\..\{-}\)>/ contains=NONE
+syn match pandocAutomaticLink /<\(https\{0,1}.\{-}\|[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~.]\{-}@[A-Za-z0-9\-]\{-}\.\w\{-}\)>/ contains=NONE
 " }}}
 "}}}
 " Citations: {{{2
@@ -615,3 +615,4 @@ let b:current_syntax = "pandoc"
 
 syntax sync clear
 syntax sync minlines=100
+

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -563,10 +563,10 @@ hi link pandocAbbreviationDefinition Comment
 hi link pandocFootnoteID Label
 hi link pandocFootnoteIDHead Type
 hi link pandocFootnoteIDTail Type
-hi link pandocFootnoteDef Type
+hi link pandocFootnoteDef Comment
 hi link pandocFootnoteDefHead Type
 hi link pandocFootnoteDefTail Type
-hi link pandocFootnoteBlock Type
+hi link pandocFootnoteBlock Comment
 hi link pandocFootnoteBlockSeparator Operator
 
 hi link pandocPCite Operator

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -269,11 +269,11 @@ syn match pandocAutomaticLink /<\(https\{0,1}.\{-}\|[A-Za-z0-9!#$%&'*+\-/=?^_`{|
 "}}}
 " Citations: {{{2
 " parenthetical citations
-syn match pandocPCite /\^\@<!\[[^\[\]]\{-}-\{0,1}@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]\{-}\([ ,;]\+.\{-}\)\{-}\]/ contains=pandocEmphasis,pandocStrong,pandocLatex,pandocCiteKey,@Spell display
+syn match pandocPCite /\^\@<!\[[^\[\]]\{-}-\{0,1}@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]*.\{-}\]/ contains=pandocEmphasis,pandocStrong,pandocLatex,pandocCiteKey,@Spell display
 " in-text citations with location
-syn match pandocICite /@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]\{-}\s\[.\{-1,}\]/ contains=pandocCiteKey,@Spell display
+syn match pandocICite /@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]*\s\[.\{-1,}\]/ contains=pandocCiteKey,@Spell display
 " cite keys
-syn match pandocCiteKey /\(-\=@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]\{-}\)\(\]\|\>\)\@=/ containedin=pandocPCite,pandocICite contains=@NoSpell display
+syn match pandocCiteKey /\(-\=@[[:alnum:]_][[:alnum:]äëïöüáéíóúàèìòùłßÄËÏÖÜÁÉÍÓÚÀÈÌÒÙŁß_:.#$%&\-+?<>~\/]*\)/ containedin=pandocPCite,pandocICite contains=@NoSpell display
 syn match pandocCiteAnchor /[-@]/ contained containedin=pandocCiteKey display
 syn match pandocCiteLocator /[\[\]]/ contained containedin=pandocPCite,pandocICite
 " }}}

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -571,7 +571,7 @@ hi link pandocFootnoteBlockSeparator Operator
 
 hi link pandocPCite Normal
 hi link pandocICite Normal
-hi link pandocCiteKey Identifier
+hi link pandocCiteKey Label
 hi link pandocCiteAnchor Operator
 hi link pandocCiteLocator Operator
 

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -59,7 +59,7 @@ else
 		\"strike": "~", 
 		\"atx": "#",  
 		\"codelang": "l",
-		\"codelang": "-",
+		\"codeend": "-",
 		\"abbrev": "a",
 		\"footnote": "f",
 		\"definition": " ",

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -405,7 +405,7 @@ call s:WithConceal('abbrev', 'syn match pandocAbbreviationTail /\]/ contained co
 "
 syn match pandocFootnoteID /\[\^[^\]]\+\]/ nextgroup=pandocFootnoteDef
 "   Inline footnotes
-syn region pandocFootnoteDef start=/\^\[/ skip=/\[.\{-}]/ end=/\]/ contains=pandocReferenceLabel,pandocReferenceURL,pandocLatex,pandocPCite,pandocCiteKey,,pandocStrong,pandocEmphasis,pandocNoFormatted,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocEnDash,pandocEmDash,pandocStrongEmphasis,pandocEllipses,pandocBeginQuote,pandocEndQuote,@Spell skipnl keepend 
+syn region pandocFootnoteDef start=/\^\[/ skip=/\[.\{-}]/ end=/\]/ contains=pandocReferenceLabel,pandocReferenceURL,pandocLatex,pandocPCite,pandocCiteKey,pandocStrong,pandocEmphasis,pandocStrongEmphasis,pandocNoFormatted,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocEnDash,pandocEmDash,pandocEllipses,pandocBeginQuote,pandocEndQuote,@Spell skipnl keepend 
 call s:WithConceal("footnote", 'syn match pandocFootnoteDefHead /\^/ contained containedin=pandocFootnoteDef', 'conceal cchar='.s:cchars["footnote"])
 ""call s:WithConceal("footnote", 'syn match pandocFootnoteDefTail /\]/ contained containedin=pandocFootnoteDef', 'conceal cchar='.s:cchars["footnote"])
 


### PR DESCRIPTION
For citation definitions, `/` does not need to be escaped when included in `[ ... ]`, so having `\/` will match either `\` or `/`. We don't want the `\` character.