### PR TITLE
Fix unicode with sub- or superscripts.

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -212,8 +212,8 @@ call s:WithConceal('html_c_e', 'syn match pandocHTMLCommentEnd /-->/ contained',
 " Unset current_syntax so the 2nd include will work
 unlet b:current_syntax
 syn include @LATEX syntax/tex.vim
-syn region pandocLaTeXInlineMath start=/\\\@<!\$[[:graph:]]\@=/ end=/\\\@<!\$/ keepend contains=@LATEX 
-syn region pandocLaTeXInlineMath start=/\\\@<!\\([[:graph:]]\@=/ end=/\\\@<!\\)/ keepend contains=@LATEX 
+syn region pandocLaTeXInlineMath start=/\v\\@<!\$\S@=/ end=/\v\\@<!\$\d@!/ keepend contains=@LATEX
+syn region pandocLaTeXInlineMath start=/\\\@<!\\(\S\@=/ end=/\\\@<!\\)\d\@!/ keepend contains=@LATEX
 syn match pandocProtectedFromInlineLaTeX /\\\@<!\${.*}\(\(\s\|[[:punct:]]\)\([^$]*\|.*\(\\\$.*\)\{2}\)\n\n\|$\)\@=/ display
 " contains=@LATEX
 syn region pandocLaTeXMathBlock start=/\$\$/ end=/\$\$/ keepend contains=@LATEX

--- a/tests/latex.pdc
+++ b/tests/latex.pdc
@@ -21,3 +21,8 @@ Age & Frequency \\ \hline
 
 # test
 
+Unicode!
+$α^i_i$
+$a^{i}_i$
+$a^i_{i}$
+$a^{i}_{i}$


### PR DESCRIPTION
Fixes most of #184.  The (unrelated) issue of `tex_math_single_backslash` mentioned there remains.