### PR TITLE
Optionally disable definition lists

### DIFF
--- a/doc/pandoc-syntax.txt
+++ b/doc/pandoc-syntax.txt
@@ -78,8 +78,8 @@ CONFIGURATION				       *vim-pandoc-syntax-configuration*
   Undeline subscript, superscript and strikeout text styles. Default = 1
 
 + *g:pandoc#syntax#style#use_definition_lists*
-  Detect and highlight definition lists. Looks really nice, but can result in
-  slower performance. Default = 1 (i.e., on by default)
+  Detect and highlight definition lists. Disabling this can improve
+  performance. Default = 1 (i.e., enabled by default)
 
 COMMANDS                                            *pandoc-syntax-commands*
 

--- a/doc/pandoc-syntax.txt
+++ b/doc/pandoc-syntax.txt
@@ -77,6 +77,10 @@ CONFIGURATION				       *vim-pandoc-syntax-configuration*
 + *g:pandoc#syntax#style#underline_special*
   Undeline subscript, superscript and strikeout text styles. Default = 1
 
++ *g:pandoc#syntax#style#use_definition_lists*
+  Detect and highlight definition lists. Looks really nice, but can result in
+  slower performance. Default = 1 (i.e., on by default)
+
 COMMANDS                                            *pandoc-syntax-commands*
 
 + *:PandocHighlight* LANG

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -132,6 +132,11 @@ if !exists('g:pandoc#syntax#roman_lists')
     let g:pandoc#syntax#roman_lists = 0
 endif
 " }}}
+" disable syntax highlighting for definition lists? (better performances) {{{2
+if !exists('g:pandoc#syntax#use_definition_lists')
+    let g:pandoc#syntax#use_definition_lists = 1
+endif
+" }}}
 "}}}1
 
 " Functions: {{{1
@@ -435,9 +440,11 @@ syn match pandocListItemContinuation /^\s\+\([-+*]\s\+\|(\?.\+[).]\)\@<!\([[:alp
 " }}}
 " Definitions: {{{2
 "
-syn region pandocDefinitionBlock start=/^\%(\_^\s*\([`~]\)\1\{2,}\)\@!.*\n\(^\s*\n\)\=\s\{0,2}[:~]\(\~\{2,}\~*\)\@!/ skip=/\n\n\zs\s/ end=/\n\n/ contains=pandocDefinitionBlockMark,pandocDefinitionBlockTerm,pandocCodeBlockInsideIndent,pandocEmphasis,pandocStrong,pandocStrongEmphasis,pandocNoFormatted,pandocStrikeout,pandocSubscript,pandocSuperscript,pandocFootnoteID,pandocReferenceURL,pandocReferenceLabel,pandocLaTeXMathBlock,pandocLaTeXInlineMath,pandocAutomaticLink,pandocEmDash,pandocEnDash,pandocFootnoteDef,pandocFootnoteBlock,pandocFootnoteID
-syn match pandocDefinitionBlockTerm /^.*\n\(^\s*\n\)\=\(\s*[:~]\)\@=/ contained contains=pandocNoFormatted,pandocEmphasis,pandocStrong,pandocLaTeXInlineMath,pandocFootnoteDef,pandocFootnoteBlock,pandocFootnoteID nextgroup=pandocDefinitionBlockMark
-call s:WithConceal("definition", 'syn match pandocDefinitionBlockMark /^\s*[:~]/ contained', 'conceal cchar='.s:cchars["definition"])
+if g:pandoc#syntax#use_definition_lists == 1
+    syn region pandocDefinitionBlock start=/^\%(\_^\s*\([`~]\)\1\{2,}\)\@!.*\n\(^\s*\n\)\=\s\{0,2}[:~]\(\~\{2,}\~*\)\@!/ skip=/\n\n\zs\s/ end=/\n\n/ contains=pandocDefinitionBlockMark,pandocDefinitionBlockTerm,pandocCodeBlockInsideIndent,pandocEmphasis,pandocStrong,pandocStrongEmphasis,pandocNoFormatted,pandocStrikeout,pandocSubscript,pandocSuperscript,pandocFootnoteID,pandocReferenceURL,pandocReferenceLabel,pandocLaTeXMathBlock,pandocLaTeXInlineMath,pandocAutomaticLink,pandocEmDash,pandocEnDash,pandocFootnoteDef,pandocFootnoteBlock,pandocFootnoteID
+    syn match pandocDefinitionBlockTerm /^.*\n\(^\s*\n\)\=\(\s*[:~]\)\@=/ contained contains=pandocNoFormatted,pandocEmphasis,pandocStrong,pandocLaTeXInlineMath,pandocFootnoteDef,pandocFootnoteBlock,pandocFootnoteID nextgroup=pandocDefinitionBlockMark
+    call s:WithConceal("definition", 'syn match pandocDefinitionBlockMark /^\s*[:~]/ contained', 'conceal cchar='.s:cchars["definition"])
+endif
 " }}}
 " Special: {{{2
 


### PR DESCRIPTION
In documents which make heavy use of definition lists, vim-pandoc causes
Vim to re-render really slowly. Rather than attempt to figure out the
cause of the slowness, I've chosen to optionally disable syntax
highlighting of definition lists.