### PR TITLE
Three improvements to LaTeX highlighting

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -218,7 +218,7 @@ call s:WithConceal('html_c_e', 'syn match pandocHTMLCommentEnd /-->/ contained',
 unlet b:current_syntax
 syn include @LATEX syntax/tex.vim
 syn region pandocLaTeXInlineMath start=/\v\\@<!\$\S@=/ end=/\v\\@<!\$\d@!/ keepend contains=@LATEX
-syn region pandocLaTeXInlineMath start=/\\\@<!\\(\S\@=/ end=/\\\@<!\\)\d\@!/ keepend contains=@LATEX
+syn region pandocLaTeXInlineMath start=/\\\@<!\\(/ end=/\\\@<!\\)/ keepend contains=@LATEX
 syn match pandocProtectedFromInlineLaTeX /\\\@<!\${.*}\(\(\s\|[[:punct:]]\)\([^$]*\|.*\(\\\$.*\)\{2}\)\n\n\|$\)\@=/ display
 " contains=@LATEX
 syn region pandocLaTeXMathBlock start=/\$\$/ end=/\$\$/ keepend contains=@LATEX

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -222,6 +222,7 @@ syn region pandocLaTeXInlineMath start=/\\\@<!\\(\S\@=/ end=/\\\@<!\\)\d\@!/ kee
 syn match pandocProtectedFromInlineLaTeX /\\\@<!\${.*}\(\(\s\|[[:punct:]]\)\([^$]*\|.*\(\\\$.*\)\{2}\)\n\n\|$\)\@=/ display
 " contains=@LATEX
 syn region pandocLaTeXMathBlock start=/\$\$/ end=/\$\$/ keepend contains=@LATEX
+syn region pandocLaTeXMathBlock start=/\\\@<!\\\[/ end=/\\\@<!\\\]/ keepend contains=@LATEX
 syn match pandocLaTeXCommand /\\[[:alpha:]]\+\(\({.\{-}}\)\=\(\[.\{-}\]\)\=\)*/ contains=@LATEX 
 syn region pandocLaTeXRegion start=/\\begin{\z(.\{-}\)}/ end=/\\end{\z1}/ keepend contains=@LATEX
 " we rehighlight sectioning commands, because otherwise tex.vim captures all text until EOF or a new sectioning command

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -239,7 +239,7 @@ syn match pandocTitleBlockTitle /\%^%.*\n/ contained containedin=pandocTitleBloc
 "}}}
 " Blockquotes: {{{2
 "
-syn match pandocBlockQuote /^\s\{,3}>.*\n\(.*\n\@1<!\n\)*/ contains=@Spell,pandocEmphasis,pandocStrong,pandocPCite,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocUListItem,pandocNoFormatted skipnl
+syn match pandocBlockQuote /^\s\{,3}>.*\n\(.*\n\@1<!\n\)*/ contains=@Spell,pandocEmphasis,pandocStrong,pandocPCite,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocUListItem,pandocNoFormatted,pandocLaTeXInlineMath,pandocLaTeXCommand,pandocLaTeXMathBlock,pandocLaTeXRegion skipnl
 syn match pandocBlockQuoteMark /\_^\s\{,3}>/ contained containedin=pandocEmphasis,pandocStrong,pandocPCite,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocUListItem,pandocNoFormatted
 
 " }}}
@@ -416,7 +416,7 @@ call s:WithConceal("footnote", 'syn match pandocFootnoteDefHead /\^\[/ contained
 call s:WithConceal("footnote", 'syn match pandocFootnoteDefTail /\]/ contained containedin=pandocFootnoteDef', 'conceal')
 
 " regular footnotes
-syn region pandocFootnoteBlock start=/\[\^.\{-}\]:\s*\n*/ end=/^\n^\s\@!/ contains=pandocReferenceLabel,pandocReferenceURL,pandocLatex,pandocPCite,pandocCiteKey,pandocStrong,pandocEmphasis,pandocNoFormatted,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocEnDash,pandocEmDash,pandocNewLine,pandocStrongEmphasis,pandocEllipses,pandocBeginQuote,pandocEndQuote,@Spell skipnl
+syn region pandocFootnoteBlock start=/\[\^.\{-}\]:\s*\n*/ end=/^\n^\s\@!/ contains=pandocReferenceLabel,pandocReferenceURL,pandocLatex,pandocPCite,pandocCiteKey,pandocStrong,pandocEmphasis,pandocNoFormatted,pandocSuperscript,pandocSubscript,pandocStrikeout,pandocEnDash,pandocEmDash,pandocNewLine,pandocStrongEmphasis,pandocEllipses,pandocBeginQuote,pandocEndQuote,pandocLaTeXInlineMath,pandocLaTeXCommand,pandocLaTeXMathBlock,pandocLaTeXRegion,@Spell skipnl
 syn match pandocFootnoteBlockSeparator /:/ contained containedin=pandocFootnoteBlock
 syn match pandocFootnoteID /\[\^.\{-}\]/ contained containedin=pandocFootnoteBlock
 call s:WithConceal("footnote", 'syn match pandocFootnoteIDHead /\[\^/ contained containedin=pandocFootnoteID', 'conceal cchar='.s:cchars["footnote"])

--- a/tests/latex.pdc
+++ b/tests/latex.pdc
@@ -1,5 +1,7 @@
 This is a paragraph with $\text{inline} \LaTeX$.
 This is a paragraph with \(\text{inline} \LaTeX\) using the tex_math_single_backslash extension.
+LaTeX: \(m\)
+LaTeX: \(m\)1 (safe for decimal to follow)
 \[
   \frac{1}{2}
 \]

--- a/tests/latex.pdc
+++ b/tests/latex.pdc
@@ -1,5 +1,8 @@
 This is a paragraph with $\text{inline} \LaTeX$.
 This is a paragraph with \(\text{inline} \LaTeX\) using the tex_math_single_backslash extension.
+\[
+  \frac{1}{2}
+\]
 
 This \$ is a dollar sign. $ this too. $30000 dollars are mentioned in pandoc's
 Example. I don't have that amount.


### PR DESCRIPTION
There are three changes in this PR. I'm happy to create separate PRs if you
only want a subset of the changes.

1.  Allow for `\[ ... \]` delimited math block (previously it was just `\( ... \)`)

2.  Correct some copy/paste errors with `\( ... \)`

    The previous regex had been copy/pasted from the regex for '$'. It was
    doing special things to try to guess if the '$' was being used for a
    monetary value.

3.  Allow LaTeX highlighting in more places (namely, in blockquotes and footnotes)

Each change is in its own commit if you want to look at them separately.