### PR TITLE
Fix #238

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -264,7 +264,7 @@ syn match pandocLinkTip /\s*".\{-}"/ contained containedin=pandocReferenceURL co
 call s:WithConceal("image", 'syn match pandocImageIcon /!\[\@=/ display', 'conceal cchar='. s:cchars["image"]) 
 " }}}
 " Definitions: {{{3
-syn region pandocReferenceDefinition start=/\[.\{-}\]:/ end=/\(\n\s*".*"$\|$\)/ keepend
+syn region pandocReferenceDefinition start="!\=\[\%(\_[^]]*]\%( \=[[(]\)\)\@=" end="\]\%( \=[[(]\)\@=" keepend
 syn match pandocReferenceDefinitionLabel /\[\zs.\{-}\ze\]:/ contained containedin=pandocReferenceDefinition display
 syn match pandocReferenceDefinitionAddress /:\s*\zs.*/ contained containedin=pandocReferenceDefinition
 syn match pandocReferenceDefinitionTip /\s*".\{-}"/ contained containedin=pandocReferenceDefinition,pandocReferenceDefinitionAddress contains=@Spell,pandocAmpersandEscape


### PR DESCRIPTION
Fixes #238 with syntax rule for links copied from `$VIMRUNTIME/syntax/markdown.vim`.