### PR TITLE
avoid double loading of syntax elements in syntax/markdown.vim

### DIFF
--- a/plugin/pandoc-syntax-check.vim
+++ b/plugin/pandoc-syntax-check.vim
@@ -1,1 +1,4 @@
 let g:vim_pandoc_syntax_exists = 1
+
+au BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md 
+                    \ let b:current_syntax = "markdown"


### PR DESCRIPTION
Please comment on this! 

In my superficial regard it seemed as if syntax/pandoc.vim highlights everything highlighted in syntax/markdown.vim under different labels. 

Which seems necessary, as for files that match *.pandoc, the markdown syntax is not loaded.