### PR TITLE
gui_running may not be set for neovim

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -647,7 +647,10 @@ if g:pandoc#syntax#style#emphases == 1
     if !exists('s:hi_tail')
         for s:i in ["fg", "bg"]
             let s:tmp_val = synIDattr(synIDtrans(hlID("String")), s:i)
-            let s:tmp_ui =  has('gui_running') || (has('termguicolors') && &termguicolors) ? 'gui' : 'cterm'
+            let s:tmp_ui = has('gui_running') ||
+                        \ (has('termguicolors') && &termguicolors) ||
+                        \ (s:tmp_val =~ '^#')
+                        \ ? 'gui' : 'cterm'
             if !empty(s:tmp_val) && s:tmp_val != -1
                 exe 'let s:'.s:i . ' = "'.s:tmp_ui.s:i.'='.s:tmp_val.'"'
             else


### PR DESCRIPTION
See discussion of "gui_running" and neovim at
https://github.com/neovim/neovim/issues/3646 and related fix at
https://github.com/junegunn/goyo.vim/commit/8faad549424d7f9173e4c2d20312b3aa93b100f1

Without this fix, running Neovim in GUI mode via neovim-dot-app, I get
messages of form:

Color name or number not recognized: ctermfg=#b1d631