### PR TITLE
WIP: Add > to each line of blockquote reflow

### DIFF
--- a/indent/pandoc.vim
+++ b/indent/pandoc.vim
@@ -1,0 +1,3 @@
+" Automatically continue blockquote on line break
+setlocal formatoptions+=r
+setlocal comments=b:>


### PR DESCRIPTION
This PR based on total ignorance of whether these changes could have
side-effects outside block quotes.

See: https://github.com/vim-pandoc/vim-pandoc-syntax/issues/325 for
context.

The code comes from:
<https://github.com/plasticboy/vim-markdown/blob/master/indent/markdown.vim#L8>