### PR TITLE
Support multiline embedded HTML tags

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -242,7 +242,7 @@ endif
 " HTML: {{{3
 " Set embedded HTML highlighting
 syn include @HTML syntax/html.vim
-syn match pandocHTML /<\/\?\a.\{-}>/ contains=@HTML
+syn match pandocHTML /<\/\?\a\_.\{-}>/ contains=@HTML
 " Support HTML multi line comments
 syn region pandocHTMLComment start=/<!--\s\=/ end=/\s\=-->/ keepend contains=pandocHTMLCommentStart,pandocHTMLCommentEnd
 call s:WithConceal('html_c_s', 'syn match pandocHTMLCommentStart /<!--/ contained', 'conceal cchar='.s:cchars['html_c_s'])


### PR DESCRIPTION
As far as I know HTML tags spanning multiple lines are valid. For example, 

```
<div class="averylongclass"
id="averylongid">
  foo
</div>
```

is valid HTML. 
Currently, only single line HTML tags are highlighted, while multiline tags are not. This PR highlights embedded multiline tags.