### PR TITLE
Beamer

### DIFF
--- a/syntax/beamer.vim
+++ b/syntax/beamer.vim
@@ -1,0 +1,5 @@
+" vim: set fdm=marker:
+
+" Pandoc: {{{1
+" load vim-pandoc-syntax {{{2
+runtime pandoc.vim

--- a/syntax/beamer.vim
+++ b/syntax/beamer.vim
@@ -2,4 +2,4 @@
 
 " Pandoc: {{{1
 " load vim-pandoc-syntax {{{2
-runtime pandoc.vim
+runtime syntax/pandoc.vim


### PR DESCRIPTION
Adds a stub `beamer.vim` syntax file that simply loads `pandoc.vim`. Having a `beamer` filetype that clones `pandoc` is useful for a separate `pandoc#command#autoexec_command`, as per [this issue](https://github.com/vim-pandoc/vim-pandoc/issues/398).