### PR TITLE
Fix things that look like tables in code blocks

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -407,7 +407,7 @@ syn match pandocLineBlockDelimiter /^|/ contained containedin=pandocLineBlock
 " Tables: {{{2
 
 " Simple: {{{3
-syn region pandocSimpleTable start=/\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)\(-\{2,}\s*\)\+\n\n\@!/ end=/\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocYAMLHeader keepend
+syn region pandocSimpleTable start=/\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)\(-\{2,}\s*\)\+\n\n\@!/ end=/\n\n/ containedin=ALLBUT,pandocDelimitedCodeBlock,pandocDelimitedCodeBlockStart,pandocYAMLHeader keepend
 syn match pandocSimpleTableDelims /\-/ contained containedin=pandocSimpleTable
 syn match pandocSimpleTableHeader /\%#=2\(^.*[[:graph:]].*\n\)\@<!\(^.*[[:graph:]].*\n\)/ contained containedin=pandocSimpleTable
 


### PR DESCRIPTION
When I have a markdown document that looks like this:

    ```yaml
    ---
    foo: bar
    ---
    ```

the `pandocDelimitedCodeBlockStart` region was tricking the `ALLBUT`,
making Vim think that it should treat the `---` as the start of a simple
table, even though it was inside a code block.

#### Before

<img width="200" alt="Screen Shot 2021-06-26 at 1 58 04 PM" src="https://user-images.githubusercontent.com/5544532/123525590-b674c600-d686-11eb-813b-befe894b1e49.png">

<img width="200" alt="Screen Shot 2021-06-26 at 1 58 22 PM" src="https://user-images.githubusercontent.com/5544532/123525589-b5dc2f80-d686-11eb-819a-442e632d3712.png">

<img width="200" alt="Screen Shot 2021-06-26 at 1 58 49 PM" src="https://user-images.githubusercontent.com/5544532/123525588-b5dc2f80-d686-11eb-9450-3fd84cfc0b3c.png">

#### After

<img width="200" alt="Screen Shot 2021-06-26 at 1 55 13 PM" src="https://user-images.githubusercontent.com/5544532/123525549-6695ff00-d686-11eb-86e7-5fb8c9d472aa.png">
