### PR TITLE
Force spellchecking on after loading syntax file

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -170,6 +170,9 @@ function! EnableEmbedsforCodeblocksWithLang(entry)
         let s:langsyntaxfile = matchstr(a:entry, '[^=]*$')
         unlet! b:current_syntax
         exe 'syn include @'.toupper(s:langname).' syntax/'.s:langsyntaxfile.'.vim'
+        " We might have just turned off spellchecking by including the file,
+        " so we turn it back on here.
+        exe 'syntax spell toplevel'
         exe 'syn region pandocDelimitedCodeBlock_' . s:langname . ' start=/\(\_^\([ ]\{4,}\|\t\)\=\(`\{3,}`*\|\~\{3,}\~*\)\s*\%({[^.]*\.\)\=' . s:langname . '\>.*\n\)\@<=\_^/' .
                     \' end=/\_$\n\(\([ ]\{4,}\|\t\)\=\(`\{3,}`*\|\~\{3,}\~*\)\_$\n\_$\)\@=/ contained containedin=pandocDelimitedCodeBlock' .
                     \' contains=@' . toupper(s:langname)


### PR DESCRIPTION
I noticed that I only had spell checking on in contained syntax regions, like
headers and list elements.

I figure that if we're okay with unconditionally setting it on at the top level
at the start of the syntax file, that we're okay with doing the same after
loading an embedded language's syntax too.

Cross reference with where we set it at the start of the file here:

https://github.com/vim-pandoc/vim-pandoc-syntax/blob/5056e635ecf406e65d7d28651bab55600dd18741/syntax/pandoc.vim#L225