### PR TITLE
Correctly highlight links without suffix

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -316,7 +316,7 @@ call s:WithConceal('image', 'syn match pandocImageIcon /!\[\@=/ display', 'conce
 " }}}3
 
 " Definitions: {{{3
-syn region pandocReferenceDefinition start="!\=\[\%(\_[^]]*]\%( \=[[(]\)\)\@=" end="\]\%( \=[[(]\)\@=" keepend
+syn region pandocReferenceDefinition start=/\[.\{-}\]:/ end=/\(\n\s*".*"$\|$\)/ keepend
 syn match pandocReferenceDefinitionLabel /\[\zs.\{-}\ze\]:/ contained containedin=pandocReferenceDefinition display
 syn match pandocReferenceDefinitionAddress /:\s*\zs.*/ contained containedin=pandocReferenceDefinition
 syn match pandocReferenceDefinitionTip /\s*".\{-}"/ contained containedin=pandocReferenceDefinition,pandocReferenceDefinitionAddress contains=@Spell,pandocAmpersandEscape


### PR DESCRIPTION
This is a revert of ad853fe0. The original changes in ad853fe0 claimed
to be in service of this snippet:

```md
Here is some mono space linked text: [`project`](https://github.com/vim-pandoc/vim-pandoc-syntax).
If I put here more `mono spaced` text, afterwards, the rest of the document is highlited wrong, try it yourself.
```

This snippet highlights completely fine, even without the changes made
in ad853fe0.

On the other hand, this change prevents this snippet from highlighting
the URL in the `[anchor]` at the bottom:

```md
This is an [anchor] tag that should be auto-linked.

[anchor]: https://example.com
```

I would love to revert the original change. Reverting it seems purely
additive to me (does not break old behaviors, adds new behaviors).

**Before**

<img width="830" alt="Screen Shot 2022-07-11 at 10 51 13 AM" src="https://user-images.githubusercontent.com/5544532/178327697-e28124c1-ca72-4248-9c21-558f0fad974e.png">

**After**

<img width="829" alt="Screen Shot 2022-07-11 at 10 51 28 AM" src="https://user-images.githubusercontent.com/5544532/178327730-e1432cdf-2550-4d59-b290-a7d0e4bfe6ab.png">

**Before**

<img width="395" alt="Screen Shot 2022-07-11 at 10 56 46 AM" src="https://user-images.githubusercontent.com/5544532/178327754-5b4ec4e1-b6f2-43f0-b0cf-a5226283b7f3.png">

**After**

<img width="401" alt="Screen Shot 2022-07-11 at 10 56 32 AM" src="https://user-images.githubusercontent.com/5544532/178327774-496009cf-13d5-47de-a974-48277ca62387.png">

Fixes #289