### PR TITLE
Setup conceal chars for quotation marks

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -51,7 +51,9 @@ if &encoding ==# 'utf-8'
                 \'definition': ' ',
                 \'li': '•',
                 \'html_c_s': '‹',
-                \'html_c_e': '›'}
+                \'html_c_e': '›',
+                \'quote_s': '“',
+                \'quote_e': '”'}
 else
     " ascii defaults
     let s:cchars = {
@@ -543,8 +545,8 @@ endif
 
 " Quotes: {{{3
 if &encoding ==# 'utf-8'
-    call s:WithConceal('quotes', 'syn match pandocBeginQuote /"\</  containedin=pandocEmphasis,pandocStrong,pandocListItem,pandocListItemContinuation,pandocUListItem display', 'conceal cchar=“')
-    call s:WithConceal('quotes', 'syn match pandocEndQuote /\(\>[[:punct:]]*\)\@<="[[:blank:][:punct:]\n]\@=/  containedin=pandocEmphasis,pandocStrong,pandocUListItem,pandocListItem,pandocListItemContinuation display', 'conceal cchar=”')
+    call s:WithConceal('quotes', 'syn match pandocBeginQuote /"\</  containedin=pandocEmphasis,pandocStrong,pandocListItem,pandocListItemContinuation,pandocUListItem display', 'conceal cchar='.s:cchars['quote_s'])
+    call s:WithConceal('quotes', 'syn match pandocEndQuote /\(\>[[:punct:]]*\)\@<="[[:blank:][:punct:]\n]\@=/  containedin=pandocEmphasis,pandocStrong,pandocUListItem,pandocListItem,pandocListItemContinuation display', 'conceal cchar='.s:cchars['quote_e'])
 endif
 " }}}3
 


### PR DESCRIPTION
Currently you cannot overwrite the characters for the quotations mark.
In French, I would prefer to have `«` and `»`, but this is not currently possible as this is hardcoded. 

This PR changes that and make the quotation marks part of the conceal dict.