### PR TITLE
Skip loading syntax/pandoc.vim if it's loaded

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -11,6 +11,10 @@ scriptencoding utf-8
 " OriginalAuthor: Jeremy Schultz <taozhyn@gmail.com>
 " Version: 5.0
 
+if exists('b:current_syntax')
+  finish
+endif
+
 " Configuration: {{{1
 "
 " use conceal? {{{2


### PR DESCRIPTION
I noticed that opening markdown files was slow and was trying to
optimize the startup.

When I run

    echo "" > foo.md
    vim --startuptime startup.log foo.md +q

I noticed in the `startup.log` that some of the heavier lines in the
trace looked redundant. Specifically, I noticed that it was running
`syntax/pandoc.vim` multiple times for multiple paths, because Neovim
seems to now distribute a `syntax/pandoc.vim` in the distribution's
`$VIMRUNTIME` path.

What's happening is that the `syntax/pandoc.vim` file loads a bunch of
other syntax files to be able to highlight embedded languages in code
blocks.

That happens every time the files are run, regardless of whether we're
already loaded a syntax definition for pandoc once, because there is no
`b:current_syntax` guard at the top of the file.

Adding the guard in this plugin doesn't actually speed anything up. The
speedup only happens when it's made both here and in the `$VIMRUNTIME`
distribution files:

    ❯ rg syntax/pandoc.vim startup.{old,new,both}.log
    startup.old.log
    272.540  025.063  003.008: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    296.343  023.082  002.412: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    297.630  000.008  000.008: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    361.296  024.097  002.412: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    385.468  023.663  002.443: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    385.853  000.007  000.007: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    146.991  028.210  003.364: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    175.621  027.840  003.237: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    176.466  000.011  000.011: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    241.812  025.036  002.764: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    269.082  026.633  003.041: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    269.506  000.009  000.009: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim

    startup.new.log
    160.321  024.925  003.534: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    184.483  022.947  002.397: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    186.524  000.008  000.008: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    251.792  022.884  002.144: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    275.302  023.001  002.316: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    275.634  000.007  000.007: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    152.428  025.671  003.712: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    176.968  023.461  002.483: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    179.083  000.008  000.008: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    243.327  023.138  002.234: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    266.798  022.957  002.340: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    267.128  000.007  000.007: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim

    startup.both.log
    175.965  027.418  003.803: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    177.070  000.007  000.007: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    178.088  000.009  000.009: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    242.550  024.351  002.335: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    243.092  000.006  000.006: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    243.447  000.007  000.007: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    147.441  026.421  003.213: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    148.317  000.008  000.008: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    149.163  000.010  000.010: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim
    219.914  026.378  002.627: sourcing /Users/jez/.config/nvim/bundle/vim-pandoc-syntax/syntax/pandoc.vim
    220.423  000.006  000.006: sourcing /opt/homebrew/Cellar/neovim/0.10.4_1/share/nvim/runtime/syntax/pandoc.vim
    220.797  000.010  000.010: sourcing /Users/jez/.config/nvim/after/syntax/pandoc.vim

    ❯ wc -l startup.{old,new,both}.log
       624 startup.old.log
       624 startup.new.log
       520 startup.both.log

What we see happening in these files is that **only** adding the
`b:current_syntax` guard in this plugin only saves ~2ms (269ms → 267ms).

But once we add it to both the plugin and the distribution, then it
completely skips running the `syntax/pandoc.vim` the second time, which
also skips loading all the embedded syntax files (represented by a drop
in the number of entries in the startup.log files from 624 lines to 520
lines). This drops the total load time from 269ms → 220ms.

For the time being, I have manually edited my
`$VIMRUNTIME/syntax/pandoc.vim` file to also include these changes, but
it will be a subsequent priority to make sure that these plugin changes
get pulled into the distribution.