### PR TITLE
Bump python version so linter works again

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.13
     - name: Setup dependencies
       run: pip install vim-vint
     - name: Run Vimscript Linter

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -7,9 +7,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.13
+        python-version: 3.10
     - name: Setup dependencies
       run: pip install vim-vint
     - name: Run Vimscript Linter

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Setup dependencies
       run: pip install vim-vint
     - name: Run Vimscript Linter


### PR DESCRIPTION
Looks like GitHub's setup-python action dropped support for Python 3.7.

The Python version hopefully doesn't matter for running vint?

I've chosen to bump to 3.10 because that's the max tested version in the vint repo's CI setup:

https://github.com/Vimjas/vint/blob/master/.github/workflows/ci.yml#L16