### PR TITLE
Don't `set cpo&vim` if we're going to early exit

### DIFF
--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -12,12 +12,12 @@ scriptencoding utf-8
 " Version: 5.0
 " Last Change:	2024 Apr 08
 
-let s:cpo_save = &cpo
-set cpo&vim
-
 if exists('b:current_syntax')
   finish
 endif
+
+let s:cpo_save = &cpo
+set cpo&vim
 
 " Configuration: {{{1
 "

--- a/syntax/pandoc.vim
+++ b/syntax/pandoc.vim
@@ -16,8 +16,8 @@ if exists('b:current_syntax')
   finish
 endif
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
 
 " Configuration: {{{1
 "
@@ -745,7 +745,7 @@ let b:current_syntax = 'pandoc'
 syntax sync clear
 syntax sync minlines=1000
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save
 
 " vim: set fdm=marker foldlevel=0:


### PR DESCRIPTION
This was a bad merge that resulted from #393 being opened before #397
but landing after.

If we override the `&cpo` option and then `finish`, it will never get
set back to the saved cpo.

Instead, let's just only do the `set` if we're sure we're not going to
early exit.